### PR TITLE
 Extend bpmn schema to store one screen summary for end events

### DIFF
--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -98,6 +98,19 @@
           "type": "String"
         }
       ]
+    },
+    {
+      "name": "EndEvent",
+      "extends": [
+        "bpmn:EndEvent"
+      ],
+      "properties": [
+        {
+          "name": "screenRef",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
     }
   ],
   "emumerations": [ ]

--- a/test/fixtures/xsd/ProcessMaker.xsd
+++ b/test/fixtures/xsd/ProcessMaker.xsd
@@ -60,7 +60,7 @@
         </xsd:complexContent>
     </xsd:complexType>
 
-    <xsd:complexType name="tPmEndEnvet">
+    <xsd:complexType name="tPmEndEvent">
         <xsd:complexContent>
             <xsd:extension base="bpmn:tEndEvent">
                 <xsd:attribute name="screenRef" type="xsd:string" use="optional"/>

--- a/test/fixtures/xsd/ProcessMaker.xsd
+++ b/test/fixtures/xsd/ProcessMaker.xsd
@@ -13,7 +13,7 @@
             <xsd:extension base="bpmn:tTask">
                 <xsd:attribute name="screenRef" type="xsd:string"/>
                 <xsd:attribute name="screenVersion" type="xsd:string" use="optional"/>
-                <xsd:attribute name="dueIn" type="xsd:date"/>
+                <xsd:attribute name="dueIn" type="xsd:decimal"/>
                 <xsd:attribute name="notifyAfterRouting" type="xsd:boolean" default="false"/>
                 <xsd:attribute name="notifyToRequestCreator" type="xsd:boolean" default="false"/>
                 <xsd:attribute name="assignment" type="xsd:string" default="requestor"/>
@@ -38,7 +38,7 @@
         <xsd:complexContent>
             <xsd:extension base="bpmn:tScriptTask">
                 <xsd:attribute name="scriptRef" type="xsd:string"/>
-                <xsd:attribute name="scriptVersion" type="xsd:string"/>
+                <xsd:attribute name="scriptVersion" type="xsd:string" use="optional"/>
                 <xsd:attribute name="config" type="xsd:string" use="optional"/>
             </xsd:extension>
         </xsd:complexContent>
@@ -60,4 +60,13 @@
         </xsd:complexContent>
     </xsd:complexType>
 
+    <xsd:complexType name="tPmEndEnvet">
+        <xsd:complexContent>
+            <xsd:extension base="bpmn:tEndEvent">
+                <xsd:attribute name="screenRef" type="xsd:string" use="optional"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
 </xsd:schema>
+


### PR DESCRIPTION
Solves #3 

- ProcessMaker.xsd  modified to include the attribute screenRef for end events
- Code for the javascript moddle mapping was added
