### PR TITLE
Allow for group assignments

### DIFF
--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -47,6 +47,11 @@
           "name": "assignedUsers",
           "isAttr": true,
           "type": "String"
+        },
+        {
+          "name": "assignedGroups",
+          "isAttr": true,
+          "type": "String"
         }
       ]
     },

--- a/test/fixtures/xml/processmaker-assignment-groups-task.part.bpmn
+++ b/test/fixtures/xml/processmaker-assignment-groups-task.part.bpmn
@@ -1,0 +1,6 @@
+<task xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+      xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd"
+      id="task"
+      name="Task"
+      pm:assignment="group"
+      pm:assignedGroups="10,20" />

--- a/test/fixtures/xml/processmaker-assignment-task.part.bpmn
+++ b/test/fixtures/xml/processmaker-assignment-task.part.bpmn
@@ -1,6 +1,6 @@
 <task xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
       xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd"
-      id="user_task"
-      name="User Task"
-      pm:assignment="cyclical"
-      pm:assignedUsers="1" />
+      id="group_task"
+      name="Group Task"
+      pm:assignment="group"
+      pm:assignedGroups="1" />

--- a/test/fixtures/xml/processmaker-group-assignment.bpmn
+++ b/test/fixtures/xml/processmaker-group-assignment.bpmn
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd"
+             targetNamespace="test">
+    <process id="UserTaskScreenTest">
+        <startEvent id="start" />
+        <sequenceFlow sourceRef="start" targetRef="usertask" />
+        <userTask id="usertask" name="Task" pm:screenRef="screen-reference-id-1" pm:assignment="requestor" />
+        <sequenceFlow sourceRef="usertask" targetRef="task2" />
+        <userTask id="task2" name="Task 2" pm:screenRef="screen-reference-id-2" pm:assignment="group" pm:assignedGroups="100" />
+    </process>
+</definitions>

--- a/test/fixtures/xml/processmaker-userTask-assignment.bpmn
+++ b/test/fixtures/xml/processmaker-userTask-assignment.bpmn
@@ -7,6 +7,6 @@
         <sequenceFlow sourceRef="start" targetRef="usertask" />
         <userTask id="usertask" name="Task" pm:screenRef="screen-reference-id-1" pm:assignment="requestor" />
         <sequenceFlow sourceRef="usertask" targetRef="task2" />
-        <userTask id="task2" name="Task 2" pm:screenRef="screen-reference-id-2" pm:assignment="cyclical" pm:assignedUsers="1" />
+        <userTask id="task2" name="Task 2" pm:screenRef="screen-reference-id-2" pm:assignment="group" pm:assignedUsers="1" />
     </process>
 </definitions>

--- a/test/fixtures/xsd/ProcessMaker.xsd
+++ b/test/fixtures/xsd/ProcessMaker.xsd
@@ -18,6 +18,7 @@
                 <xsd:attribute name="notifyToRequestCreator" type="xsd:boolean" default="false"/>
                 <xsd:attribute name="assignment" type="xsd:string" default="requestor"/>
                 <xsd:attribute name="assignedUsers" type="xsd:string"/>
+                <xsd:attribute name="assignedGroups" type="xsd:string"/>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>
@@ -32,6 +33,7 @@
                 <xsd:attribute name="notifyToRequestCreator" type="xsd:boolean" default="false"/>
                 <xsd:attribute name="assignment" type="xsd:string" default="requestor"/>
                 <xsd:attribute name="assignedUsers" type="xsd:string"/>
+                <xsd:attribute name="assignedGroups" type="xsd:string"/>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -63,10 +63,10 @@ describe('read', function() {
                 // then
                 expect(task).to.jsonEqual({
                     '$type': 'bpmn:Task',
-                    id: 'user_task',
-                    name: 'User Task',
-                    assignment: 'cyclical',
-                    assignedUsers: '1',
+                    id: 'group_task',
+                    name: 'Group Task',
+                    assignment: 'group',
+                    assignedGroups: '1',
                 });
                 done(err);
             });

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -136,6 +136,24 @@ describe('read', function() {
             });
         });
 
+        it('Load assignedGroups from Task', function(done) {
+
+            // given
+            var xml = readFile('test/fixtures/xml/processmaker-assignment-groups-task.part.bpmn');
+
+            // when
+            moddle.fromXML(xml, 'bpmn:Task', function(err, task) {
+                // then
+                expect(task).to.jsonEqual({
+                    '$type': 'bpmn:Task',
+                    id: 'task',
+                    name: 'Task',
+                    assignment: 'group',
+                    assignedGroups: '10,20',
+                });
+                done(err);
+            });
+        });
 
     });
 

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -55,6 +55,8 @@ describe('import -> export roundtrip', function() {
         it('pm:scriptRef & pm:scriptVersion', validateExport('test/fixtures/xml/processmaker-scriptTask.bpmn'));
 
         it('EndEvent pm:screenRef & pm:screenVersion', validateExport('test/fixtures/xml/processmaker-endEvent.bpmn'));
+
+        it('Task group assignment', validateExport('test/fixtures/xml/processmaker-group-assignment.bpmn'));
     });
 
 });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -171,6 +171,7 @@ describe('write', function() {
                 'notifyRequestCreator': false,
                 'assignment': 'group',
                 'assignedUsers': '10,20',
+                'assignedGroups': '999',
             });
 
             var expectedXML =
@@ -179,7 +180,7 @@ describe('write', function() {
               'name="Task_1" pm:screenRef="screen-001-000" ' +
               'pm:screenVersion="1" pm:dueIn="3" ' +
               'pm:notifyAfterRouting="true" pm:notifyRequestCreator="false" ' +
-              'pm:assignment="group" pm:assignedUsers="10,20" />';
+              'pm:assignment="group" pm:assignedUsers="10,20" pm:assignedGroups="999" />';
 
             // when
             write(fieldElem, function(err, result) {

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -159,6 +159,38 @@ describe('write', function() {
             });
         });
 
+        it('Write Task Group Assignment', function(done) {
+
+            // given
+            var fieldElem = moddle.create('bpmn:Task', {
+                'name': 'Task_1',
+                'screenRef': 'screen-001-000',
+                'screenVersion': '1',
+                'dueIn': 3,
+                'notifyAfterRouting': true,
+                'notifyRequestCreator': false,
+                'assignment': 'group',
+                'assignedUsers': '10,20',
+            });
+
+            var expectedXML =
+              '<bpmn:task xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+              'xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" ' +
+              'name="Task_1" pm:screenRef="screen-001-000" ' +
+              'pm:screenVersion="1" pm:dueIn="3" ' +
+              'pm:notifyAfterRouting="true" pm:notifyRequestCreator="false" ' +
+              'pm:assignment="group" pm:assignedUsers="10,20" />';
+
+            // when
+            write(fieldElem, function(err, result) {
+
+                // then
+                expect(result).to.eql(expectedXML);
+
+                done(err);
+            });
+        });
+
     });
 
 });


### PR DESCRIPTION
Adds an attribute to the BPM for `groupAssignments` (we are not supporting multiple group assignments but the name is plural for BPMN standards)