### PR TITLE
Additional properties for Intermediate Catch, Message Event and Sequence Flow

### DIFF
--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -161,6 +161,55 @@
       ]
     },
     {
+      "name": "IntermediateCatchEvent",
+      "extends": [
+        "bpmn:IntermediateCatchEvent"
+      ],
+      "properties": [
+        {
+          "name": "allowedUsers",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "allowedGroups",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "whitelist",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "MessageEventDefinition",
+      "extends": [
+        "bpmn:MessageEventDefinition"
+      ],
+      "properties": [
+        {
+          "name": "dataName",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "MessageEventDefinition",
+      "extends": [
+        "bpmn:MessageEventDefinition"
+      ],
+      "properties": [
+        {
+          "name": "dataName",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
       "name": "SequenceFlow",
       "extends": [
         "bpmn:SequenceFlow"

--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -159,6 +159,19 @@
           "type": "String"
         }
       ]
+    },
+    {
+      "name": "SequenceFlow",
+      "extends": [
+        "bpmn:SequenceFlow"
+      ],
+      "properties": [
+        {
+          "name": "startEvent",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
     }
   ],
   "emumerations": [ ]

--- a/test/fixtures/xsd/ProcessMaker.xsd
+++ b/test/fixtures/xsd/ProcessMaker.xsd
@@ -87,5 +87,31 @@
         </xsd:complexContent>
     </xsd:complexType>
 
+    <xsd:complexType name="tPmIntermediateCatchEvent">
+        <xsd:complexContent>
+            <xsd:extension base="bpmn:tIntermediateCatchEvent">
+                <xsd:attribute name="allowedUsers" type="xsd:string" use="optional"/>
+                <xsd:attribute name="allowedGroups" type="xsd:string" use="optional"/>
+                <xsd:attribute name="whitelist" type="xsd:string" use="optional"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="tPmMessageEventDefinition">
+        <xsd:complexContent>
+            <xsd:extension base="bpmn:tMessageEventDefinition">
+                <xsd:attribute name="dataName" type="xsd:string" use="optional"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="tPmSequenceFlow">
+        <xsd:complexContent>
+            <xsd:extension base="bpmn:tSequenceFlow">
+                <xsd:attribute name="startEvent" type="xsd:string" use="optional"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
 </xsd:schema>
 

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -238,9 +238,9 @@ describe('read', function() {
             var xml = readFile('test/fixtures/xml/processmaker-intermediate-catch-event.part.bpmn');
 
             // when
-            moddle.fromXML(xml, 'bpmn:IntermediateCatchEvent', function(err, task) {
+            moddle.fromXML(xml, 'bpmn:IntermediateCatchEvent', function(err, element) {
                 // then
-                expect(task).to.jsonEqual({
+                expect(element).to.jsonEqual({
                     '$type': 'bpmn:IntermediateCatchEvent',
                     id: 'catch',
                     name: 'Catch',
@@ -258,10 +258,10 @@ describe('read', function() {
             var xml = readFile('test/fixtures/xml/processmaker-message-definition.part.bpmn');
 
             // when
-            moddle.fromXML(xml, 'bpmn:MessageDefinition', function(err, task) {
+            moddle.fromXML(xml, 'bpmn:MessageEventDefinition', function(err, element) {
                 // then
-                expect(task).to.jsonEqual({
-                    '$type': 'bpmn:MessageDefinition',
+                expect(element).to.jsonEqual({
+                    '$type': 'bpmn:MessageEventDefinition',
                     id: 'message',
                     dataName: 'order',
                 });
@@ -275,14 +275,12 @@ describe('read', function() {
             var xml = readFile('test/fixtures/xml/processmaker-sequence-flow-start-event.part.bpmn');
 
             // when
-            moddle.fromXML(xml, 'bpmn:SequenceFlow', function(err, task) {
+            moddle.fromXML(xml, 'bpmn:SequenceFlow', function(err, element) {
                 // then
-                expect(task).to.jsonEqual({
+                expect(element).to.jsonEqual({
                     '$type': 'bpmn:SequenceFlow',
                     id: 'sequence_flow',
-                    sourceRef: 'id1',
-                    targetRef: 'id2',
-                    startEvent: 'id3',
+                    startEvent: 'startId',
                 });
                 done(err);
             });

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -232,6 +232,62 @@ describe('read', function() {
             });
         });
 
+        it('Load Intermediate Catch Event', function(done) {
+
+            // given
+            var xml = readFile('test/fixtures/xml/processmaker-intermediate-catch-event.part.bpmn');
+
+            // when
+            moddle.fromXML(xml, 'bpmn:IntermediateCatchEvent', function(err, task) {
+                // then
+                expect(task).to.jsonEqual({
+                    '$type': 'bpmn:IntermediateCatchEvent',
+                    id: 'catch',
+                    name: 'Catch',
+                    allowedUsers: '1,2',
+                    allowedGroups: '10,20',
+                    whitelist: '192.168.1.1/24,*.example.com',
+                });
+                done(err);
+            });
+        });
+
+        it('Load Message Definition', function(done) {
+
+            // given
+            var xml = readFile('test/fixtures/xml/processmaker-message-definition.part.bpmn');
+
+            // when
+            moddle.fromXML(xml, 'bpmn:MessageDefinition', function(err, task) {
+                // then
+                expect(task).to.jsonEqual({
+                    '$type': 'bpmn:MessageDefinition',
+                    id: 'message',
+                    dataName: 'order',
+                });
+                done(err);
+            });
+        });
+
+        it('Load Sequence Flow with Start Event', function(done) {
+
+            // given
+            var xml = readFile('test/fixtures/xml/processmaker-sequence-flow-start-event.part.bpmn');
+
+            // when
+            moddle.fromXML(xml, 'bpmn:SequenceFlow', function(err, task) {
+                // then
+                expect(task).to.jsonEqual({
+                    '$type': 'bpmn:SequenceFlow',
+                    id: 'sequence_flow',
+                    sourceRef: 'id1',
+                    targetRef: 'id2',
+                    startEvent: 'id3',
+                });
+                done(err);
+            });
+        });
+
     });
 
 });

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -63,6 +63,10 @@ describe('import -> export roundtrip', function() {
         it('Task group assignment', validateExport('test/fixtures/xml/processmaker-task-reassignment.bpmn'));
 
         it('Start event assignment', validateExport('test/fixtures/xml/processmaker-startEvent-assignment.bpmn'));
+
+        it('Intermediate Catch Message Event', validateExport('test/fixtures/xml/processmaker-intermediate-catch-event.bpmn'));
+
+        it('Call Activity', validateExport('test/fixtures/xml/processmaker-call-activity.bpmn'));
     });
 
 });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -314,6 +314,87 @@ describe('write', function() {
             });
         });
 
+        it('Write Intermediate Catch Event', function(done) {
+
+            // given
+            var fieldElem = moddle.create('bpmn:IntermediateCatchEvent', {
+                id: 'catch',
+                name: 'catch',
+                allowedUsers: '1,2',
+                allowedGroups: '10,20',
+                whitelist: '192.168.1.1/24,*.example.com',
+            });
+
+            var expectedXML =
+              '<bpmn:IntermediateCatchEvent xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+              'xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" ' +
+              'id="catch" ' +
+              'name="catch" ' +
+              'pm:allowedUsers="1,2" pm:allowedGroups="10,20" '+
+              'pm:whitelist="192.168.1.1/24,*.example.com" />';
+
+            // when
+            write(fieldElem, function(err, result) {
+
+                // then
+                expect(result).to.eql(expectedXML);
+
+                done(err);
+            });
+        });
+
+        it('Write Message Definition', function(done) {
+
+            // given
+            var fieldElem = moddle.create('bpmn:MessageDefinition', {
+                id: 'message',
+                dataName: 'order',
+            });
+
+            var expectedXML =
+              '<bpmn:MessageDefinition xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+              'xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" ' +
+              'id="message" ' +
+              'pm:dataName="order" />';
+
+            // when
+            write(fieldElem, function(err, result) {
+
+                // then
+                expect(result).to.eql(expectedXML);
+
+                done(err);
+            });
+        });
+
+        it('Write Sequence Flow with Start Event', function(done) {
+
+            // given
+            var fieldElem = moddle.create('bpmn:SequenceFlow', {
+                id: 'sequence_flow',
+                sourceRef: 'id1',
+                targetRef: 'id2',
+                startEvent: 'id3',
+            });
+
+            var expectedXML =
+              '<bpmn:SequenceFlow xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+              'xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" ' +
+              'id="sequence_flow" ' +
+              'sourceRef="id1" ' +
+              'targetRef="id2" ' +
+              'pm:dataName="id3" />';
+
+            // when
+            write(fieldElem, function(err, result) {
+
+                // then
+                expect(result).to.eql(expectedXML);
+
+                done(err);
+            });
+        });
+
     });
 
 });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -326,7 +326,7 @@ describe('write', function() {
             });
 
             var expectedXML =
-              '<bpmn:IntermediateCatchEvent xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+              '<bpmn:intermediateCatchEvent xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
               'xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" ' +
               'id="catch" ' +
               'name="catch" ' +
@@ -346,13 +346,13 @@ describe('write', function() {
         it('Write Message Definition', function(done) {
 
             // given
-            var fieldElem = moddle.create('bpmn:MessageDefinition', {
+            var fieldElem = moddle.create('bpmn:MessageEventDefinition', {
                 id: 'message',
                 dataName: 'order',
             });
 
             var expectedXML =
-              '<bpmn:MessageDefinition xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+              '<bpmn:messageEventDefinition xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
               'xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" ' +
               'id="message" ' +
               'pm:dataName="order" />';
@@ -372,18 +372,14 @@ describe('write', function() {
             // given
             var fieldElem = moddle.create('bpmn:SequenceFlow', {
                 id: 'sequence_flow',
-                sourceRef: 'id1',
-                targetRef: 'id2',
                 startEvent: 'id3',
             });
 
             var expectedXML =
-              '<bpmn:SequenceFlow xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+              '<bpmn:sequenceFlow xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
               'xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" ' +
               'id="sequence_flow" ' +
-              'sourceRef="id1" ' +
-              'targetRef="id2" ' +
-              'pm:dataName="id3" />';
+              'pm:startEvent="id3" />';
 
             // when
             write(fieldElem, function(err, result) {


### PR DESCRIPTION
Resolves #15 
Resolves #14 

For intermediate catch events:
```
<intermediateCatchEvent id="_2"
    name="Intermediate Catch Event Name"
    pm:allowedUsers="1,10"
    pm:allowedGroups="20,30"
    pm:whitelist="192.168.1.1/24,*.example.com">
  <messageEventDefinition id="_2_ED_1" pm:dataName="docusign_event"/>
</intermediateCatchEvent>
```
For Call Activities:
```
        <sequenceFlow sourceRef="start" targetRef="callActivity" pm:startEvent="externalStart" />
        <callActivity id="callActivity" name="CallActivity" calledElement="1000:ProcessId" />
```
