### PR TITLE
Add support for pm:validations to multiple node types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 nbproject/
 node_modules/
+.DS_Store

--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -67,6 +67,11 @@
           "name": "config",
           "isAttr": true,
           "type": "String"
+        },
+        {
+          "name": "validations",
+          "isAttr": true,
+          "type": "String"
         }
       ]
     },

--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -157,6 +157,11 @@
           "name": "config",
           "isAttr": true,
           "type": "String"
+        },
+        {
+          "name": "validations",
+          "isAttr": true,
+          "type": "String"
         }
       ]
     },

--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -90,6 +90,11 @@
           "name": "scriptVersion",
           "isAttr": true,
           "type": "String"
+        },
+        {
+          "name": "validations",
+          "isAttr": true,
+          "type": "String"
         }
       ]
     },
@@ -101,6 +106,11 @@
       "properties": [
         {
           "name": "implementationVersion",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "validations",
           "isAttr": true,
           "type": "String"
         }

--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -190,6 +190,11 @@
           "name": "whitelist",
           "isAttr": true,
           "type": "String"
+        },
+        {
+          "name": "validations",
+          "isAttr": true,
+          "type": "String"
         }
       ]
     },

--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -232,6 +232,11 @@
           "name": "config",
           "isAttr": true,
           "type": "String"
+        },
+        {
+          "name": "validations",
+          "isAttr": true,
+          "type": "String"
         }
       ]
     }

--- a/test/fixtures/xml/processmaker-assignment-groups-startEvent.part.bpmn
+++ b/test/fixtures/xml/processmaker-assignment-groups-startEvent.part.bpmn
@@ -5,4 +5,4 @@
       pm:assignment="group"
       pm:assignedGroups="10,20"
       pm:config="{}"
-      pm:validations="[]" />
+      pm:validations="1,2,3" />

--- a/test/fixtures/xml/processmaker-assignment-groups-startEvent.part.bpmn
+++ b/test/fixtures/xml/processmaker-assignment-groups-startEvent.part.bpmn
@@ -4,4 +4,5 @@
       name="Start Event"
       pm:assignment="group"
       pm:assignedGroups="10,20"
-      pm:config="{}" />
+      pm:config="{}"
+      pm:validations="[]" />

--- a/test/fixtures/xml/processmaker-assignment-startEvent.part.bpmn
+++ b/test/fixtures/xml/processmaker-assignment-startEvent.part.bpmn
@@ -5,4 +5,4 @@
       pm:assignment="user"
       pm:assignedUsers="1"
       pm:config="{}"
-      pm:validations="[]" />
+      pm:validations="1,2,3" />

--- a/test/fixtures/xml/processmaker-assignment-startEvent.part.bpmn
+++ b/test/fixtures/xml/processmaker-assignment-startEvent.part.bpmn
@@ -4,4 +4,5 @@
       name="Start Event"
       pm:assignment="user"
       pm:assignedUsers="1"
-      pm:config="{}" />
+      pm:config="{}"
+      pm:validations="[]" />

--- a/test/fixtures/xml/processmaker-call-activity.part.bpmn
+++ b/test/fixtures/xml/processmaker-call-activity.part.bpmn
@@ -4,4 +4,4 @@
       name="Call Activity 1"
       calledElement="ProcessId-123"
       pm:config="{}"
-      validations="[]" />
+      validations="1,2,3" />

--- a/test/fixtures/xml/processmaker-call-activity.part.bpmn
+++ b/test/fixtures/xml/processmaker-call-activity.part.bpmn
@@ -3,4 +3,5 @@
       id="call-activity-1"
       name="Call Activity 1"
       calledElement="ProcessId-123"
-      pm:config="{}" />
+      pm:config="{}"
+      validations="[]" />

--- a/test/fixtures/xml/processmaker-intermediate-catch-event.part.bpmn
+++ b/test/fixtures/xml/processmaker-intermediate-catch-event.part.bpmn
@@ -4,4 +4,5 @@
       name="Catch"
       pm:allowedUsers="1,2"
       pm:allowedGroups="10,20"
-      pm:whitelist="192.168.1.1/24,*.example.com" />
+      pm:whitelist="192.168.1.1/24,*.example.com"
+      pm:validations="1,2,3" />

--- a/test/fixtures/xml/processmaker-startEvent-assignment.bpmn
+++ b/test/fixtures/xml/processmaker-startEvent-assignment.bpmn
@@ -3,9 +3,9 @@
              xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd"
              targetNamespace="test">
     <process id="UserTaskScreenTest">
-        <startEvent id="start" pm:assignment="group" pm:assignedGroups="1" pm:config="{}" />
+        <startEvent id="start" pm:assignment="group" pm:assignedGroups="1" pm:config="{}" pm:validations="[]" />
         <sequenceFlow sourceRef="start" targetRef="usertask" />
-        <startEvent id="start2" pm:assignment="user" pm:assignedUsers="1"  pm:config="{}" />
+        <startEvent id="start2" pm:assignment="user" pm:assignedUsers="1"  pm:config="{}" pm:validations="[]" />
         <sequenceFlow sourceRef="start2" targetRef="task2" />
         <userTask id="usertask" name="Task" pm:screenRef="screen-reference-id-1" pm:assignment="requestor" />
         <sequenceFlow sourceRef="usertask" targetRef="task2" />

--- a/test/fixtures/xml/processmaker-startEvent-assignment.bpmn
+++ b/test/fixtures/xml/processmaker-startEvent-assignment.bpmn
@@ -3,9 +3,9 @@
              xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd"
              targetNamespace="test">
     <process id="UserTaskScreenTest">
-        <startEvent id="start" pm:assignment="group" pm:assignedGroups="1" pm:config="{}" pm:validations="[]" />
+        <startEvent id="start" pm:assignment="group" pm:assignedGroups="1" pm:config="{}" pm:validations="1,2,3" />
         <sequenceFlow sourceRef="start" targetRef="usertask" />
-        <startEvent id="start2" pm:assignment="user" pm:assignedUsers="1"  pm:config="{}" pm:validations="[]" />
+        <startEvent id="start2" pm:assignment="user" pm:assignedUsers="1"  pm:config="{}" pm:validations="1,2,3" />
         <sequenceFlow sourceRef="start2" targetRef="task2" />
         <userTask id="usertask" name="Task" pm:screenRef="screen-reference-id-1" pm:assignment="requestor" />
         <sequenceFlow sourceRef="usertask" targetRef="task2" />

--- a/test/fixtures/xml/processmaker-task-screen.part.bpmn
+++ b/test/fixtures/xml/processmaker-task-screen.part.bpmn
@@ -10,4 +10,5 @@
       pm:notifyAfterRouting="true"
       pm:notifyRequestCreator="false"
       startQuantity="1"
-      pm:config="{}" />
+      pm:config="{}"
+      validations="1,2,3" />

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -106,6 +106,7 @@ describe('read', function() {
                     'name': 'Call Activity 1',
                     'calledElement': 'ProcessId-123',
                     'config': '{}',
+                    'validations': '[]',
                 });
                 done(err);
             });

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -106,7 +106,7 @@ describe('read', function() {
                     'name': 'Call Activity 1',
                     'calledElement': 'ProcessId-123',
                     'config': '{}',
-                    'validations': '[]',
+                    'validations': '1,2,3',
                 });
                 done(err);
             });
@@ -230,7 +230,7 @@ describe('read', function() {
                     assignment: 'user',
                     assignedUsers: '1',
                     config: "{}",
-                    validations: '[]',
+                    validations: '1,2,3',
                 });
                 done(err);
             });
@@ -251,7 +251,7 @@ describe('read', function() {
                     assignment: 'group',
                     assignedGroups: '10,20',
                     config: "{}",
-                    validations: '[]',
+                    validations: '1,2,3',
                 });
                 done(err);
             });

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -273,6 +273,7 @@ describe('read', function() {
                     allowedUsers: '1,2',
                     allowedGroups: '10,20',
                     whitelist: '192.168.1.1/24,*.example.com',
+                    validations: '1,2,3',
                 });
                 done(err);
             });

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -132,7 +132,8 @@ describe('read', function() {
                     'notifyAfterRouting': true,
                     'notifyRequestCreator': false,
                     'startQuantity': 1,
-                    'config': '{}'
+                    'config': '{}',
+                    'validations': '1,2,3'
                 });
                 done(err);
             });

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -215,7 +215,7 @@ describe('read', function() {
             });
         });
 
-        it('Load Star Event Assignment', function(done) {
+        it('Load Start Event Assignment', function(done) {
 
             // given
             var xml = readFile('test/fixtures/xml/processmaker-assignment-startEvent.part.bpmn');
@@ -230,12 +230,13 @@ describe('read', function() {
                     assignment: 'user',
                     assignedUsers: '1',
                     config: "{}",
+                    validations: '[]',
                 });
                 done(err);
             });
         });
 
-        it('Load Star Event Group Assignment', function(done) {
+        it('Load Start Event Group Assignment', function(done) {
 
             // given
             var xml = readFile('test/fixtures/xml/processmaker-assignment-groups-startEvent.part.bpmn');
@@ -250,6 +251,7 @@ describe('read', function() {
                     assignment: 'group',
                     assignedGroups: '10,20',
                     config: "{}",
+                    validations: '[]',
                 });
                 done(err);
             });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -277,13 +277,14 @@ describe('write', function() {
                 'assignment': 'user',
                 'assignedUsers': '1,2',
                 'config': '{}',
+                'validations': '[]',
             });
 
             var expectedXML =
               '<bpmn:startEvent xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
               'xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" ' +
               'name="start" ' +
-              'pm:assignment="user" pm:assignedUsers="1,2" pm:config="{}" />';
+              'pm:assignment="user" pm:assignedUsers="1,2" pm:config="{}" pm:validations="[]" />';
 
             // when
             write(fieldElem, function(err, result) {

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -332,6 +332,7 @@ describe('write', function() {
                 allowedUsers: '1,2',
                 allowedGroups: '10,20',
                 whitelist: '192.168.1.1/24,*.example.com',
+                validations: '1,2,3',
             });
 
             var expectedXML =
@@ -340,7 +341,8 @@ describe('write', function() {
               'id="catch" ' +
               'name="catch" ' +
               'pm:allowedUsers="1,2" pm:allowedGroups="10,20" '+
-              'pm:whitelist="192.168.1.1/24,*.example.com" />';
+              'pm:whitelist="192.168.1.1/24,*.example.com" ' +
+              'pm:validations="1,2,3" />';
 
             // when
             write(fieldElem, function(err, result) {

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -277,14 +277,14 @@ describe('write', function() {
                 'assignment': 'user',
                 'assignedUsers': '1,2',
                 'config': '{}',
-                'validations': '[]',
+                'validations': '1,2,3',
             });
 
             var expectedXML =
               '<bpmn:startEvent xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
               'xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" ' +
               'name="start" ' +
-              'pm:assignment="user" pm:assignedUsers="1,2" pm:config="{}" pm:validations="[]" />';
+              'pm:assignment="user" pm:assignedUsers="1,2" pm:config="{}" pm:validations="1,2,3" />';
 
             // when
             write(fieldElem, function(err, result) {

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -407,6 +407,7 @@ describe('write', function() {
             'name': 'Call Activity 1',
             'calledElement': 'ProcessId-123',
             'config': '{"message":"hello"}',
+            'validations': '[1, 2, 3]'
         });
 
         var expectedXML =
@@ -414,7 +415,8 @@ describe('write', function() {
           'xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" ' +
           'name="Call Activity 1" ' +
           'calledElement="ProcessId-123" ' +
-          'pm:config="{&#34;message&#34;:&#34;hello&#34;}" />';
+          'pm:config="{&#34;message&#34;:&#34;hello&#34;}" ' +
+          'pm:validations="[1, 2, 3]" />';
 
         // when
         write(fieldElem, function(err, result) {

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -113,7 +113,8 @@ describe('write', function() {
                 'notifyRequestCreator': false,
                 'assignment': 'user',
                 'assignedUsers': '1',
-                'config': "{}"
+                'config': "{}",
+                'validations': '1,2,3'
             });
 
             var expectedXML =
@@ -122,7 +123,7 @@ describe('write', function() {
               'name="Task_1" pm:screenRef="screen-001-000" ' +
               'pm:screenVersion="10" pm:dueIn="3" ' +
               'pm:notifyAfterRouting="true" pm:notifyRequestCreator="false" ' +
-              'pm:assignment="user" pm:assignedUsers="1" pm:config="{}" />';
+              'pm:assignment="user" pm:assignedUsers="1" pm:config="{}" pm:validations="1,2,3" />';
 
             // when
             write(fieldElem, function(err, result) {


### PR DESCRIPTION
## Changes
- Adds support for the new pm:validations attribute to:
  - Call Activity
  - Start Event
  - Tasks
  - Intermediate catch events
  - Script tasks
- Updates tests to support this new attribute

Closes #26.