### PR TITLE
Add interstitial attributes to StartEvent

### DIFF
--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -159,6 +159,16 @@
       ],
       "properties": [
         {
+          "name": "allowInterstitial",
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "interstitialScreenRef",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
           "name": "assignment",
           "isAttr": true,
           "type": "String"

--- a/test/fixtures/xml/processmaker-startEvent-interstitial.bpmn
+++ b/test/fixtures/xml/processmaker-startEvent-interstitial.bpmn
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd"
+             targetNamespace="test">
+    <process id="process_1">
+        <startEvent id="start" pm:allowInterstitial="true" pm:interstitialScreenRef="screen-000-000-0001" />
+        <sequenceFlow sourceRef="start" targetRef="usertask" />
+        <userTask id="usertask" name="Task" pm:screenRef="screen-reference-id-1" pm:allowInterstitial="true" pm:interstitialScreenRef="screen-000-000-0001" />
+        <sequenceFlow sourceRef="usertask" targetRef="task2" />
+        <userTask id="task2" name="Task 2" pm:screenRef="screen-reference-id-2" pm:assignment="group" pm:assignedGroups="100" pm:allowReassignment="true" />
+    </process>
+</definitions>

--- a/test/fixtures/xml/processmaker-startEvent-interstitial.part.bpmn
+++ b/test/fixtures/xml/processmaker-startEvent-interstitial.part.bpmn
@@ -1,0 +1,7 @@
+<startEvent xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+      xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd"
+      id="start"
+      name="Start Event"
+      pm:allowInterstitial="true"
+      pm:interstitialScreenRef="screen-000-000-0001"
+      />

--- a/test/fixtures/xsd/ProcessMaker.xsd
+++ b/test/fixtures/xsd/ProcessMaker.xsd
@@ -92,6 +92,8 @@
                 <xsd:attribute name="assignedUsers" type="xsd:string" use="optional"/>
                 <xsd:attribute name="assignedGroups" type="xsd:string" use="optional"/>
                 <xsd:attribute name="config" type="xsd:string" use="optional"/>
+                <xsd:attribute name="allowInterstitial" type="xsd:boolean" default="false"/>
+                <xsd:attribute name="interstitialScreenRef" type="xsd:string"/>
             </xsd:extension>
         </xsd:complexContent>
     </xsd:complexType>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -265,6 +265,25 @@ describe('read', function() {
             });
         });
 
+        it('Load Start Event Interstitial', function(done) {
+
+            // given
+            var xml = readFile('test/fixtures/xml/processmaker-startEvent-interstitial.part.bpmn');
+
+            // when
+            moddle.fromXML(xml, 'bpmn:StartEvent', function(err, task) {
+                // then
+                expect(task).to.jsonEqual({
+                    '$type': 'bpmn:StartEvent',
+                    id: 'start',
+                    name: 'Start Event',
+                    allowInterstitial: true,
+                    interstitialScreenRef: 'screen-000-000-0001',
+                });
+                done(err);
+            });
+        });
+
         it('Load Start Event Assignment', function(done) {
 
             // given

--- a/test/spec/xml/roundtrip.js
+++ b/test/spec/xml/roundtrip.js
@@ -68,7 +68,9 @@ describe('import -> export roundtrip', function() {
 
         it('Call Activity', validateExport('test/fixtures/xml/processmaker-call-activity.bpmn'));
 
-        it('pm:allowInterstitial & pm:interstitialScreenRef', validateExport('test/fixtures/xml/processmaker-task-interstitial.bpmn'));
+        it('Task pm:allowInterstitial & pm:interstitialScreenRef', validateExport('test/fixtures/xml/processmaker-task-interstitial.bpmn'));
+
+        it('Start Event pm:allowInterstitial & pm:interstitialScreenRef', validateExport('test/fixtures/xml/processmaker-startEvent-interstitial.bpmn'));
     });
 
 });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -504,4 +504,29 @@ describe('write', function() {
         });
     });
 
+    it('Write Start Event Interstitial attributes', function(done) {
+
+        // given
+        var fieldElem = moddle.create('bpmn:StartEvent', {
+            'name': 'Start',
+            'allowInterstitial': true,
+            'interstitialScreenRef': 'screen-002-000'
+        });
+
+        var expectedXML =
+          '<bpmn:startEvent xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+          'xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" ' +
+          'name="Start" pm:allowInterstitial="true" ' +
+          'pm:interstitialScreenRef="screen-002-000" ' +
+          '/>';
+
+        // when
+        write(fieldElem, function(err, result) {
+
+            // then
+            expect(result).to.eql(expectedXML);
+
+            done(err);
+        });
+    });
 });


### PR DESCRIPTION
Resolves #34 

This PR includes:

- Add a boolean **allowInterstitial** to StartEvent
- Add a string **interstitialScreenRef** to StartEvent
- Add tests to read/write/build BPMN code with the new attributes
