### PR TITLE
Fix modeler #1250 (Color picker emits invalid BPMN, breaking the ability to create requests)

### DIFF
--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -8,6 +8,20 @@
   "associations": [],
   "types": [
     {
+      "name": "BaseElement",
+      "extends": [
+        "bpmn:BaseElement"
+      ],
+      "isAbstract": true,
+      "properties": [
+        {
+          "name": "color",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
       "name": "Task",
       "extends": [
         "bpmn:Task"

--- a/test/fixtures/xml/processmaker-task-color.part.bpmn
+++ b/test/fixtures/xml/processmaker-task-color.part.bpmn
@@ -1,0 +1,6 @@
+<task xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+      xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd"
+      id="task"
+      name="Task"
+      pm:color="#336699"
+/>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -139,6 +139,24 @@ describe('read', function() {
             });
         });
 
+        it('Load Task With Color', function(done) {
+
+            // given
+            var xml = readFile('test/fixtures/xml/processmaker-task-color.part.bpmn');
+
+            // when
+            moddle.fromXML(xml, 'bpmn:Task', function(err, task) {
+                // then
+                expect(task).to.jsonEqual({
+                    '$type': 'bpmn:Task',
+                    'id': 'task',
+                    'name': 'Task',
+                    'color': '#336699'
+                });
+                done(err);
+            });
+        });
+
         it('Load Interstitial Configuration', function(done) {
 
             // given

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -503,6 +503,29 @@ describe('write', function() {
         });
     });
 
+    it('Can write task with color as pm:color', function(done) {
+
+        const withColorAttribute = {
+            name: 'Task',
+            color: '#336699'
+        };
+
+        const taskWithColorAttribute = moddle.create('bpmn:Task', withColorAttribute);
+
+        const expectedPmNamespace = 'xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd"';
+        const expectedName = `name="${withColorAttribute.name}"`;
+        const expectedPmNamespacedColor = `pm:color="${withColorAttribute.color}"`;
+
+        write(taskWithColorAttribute, function(err, outputXml) {
+
+            expect(outputXml).to.contain(expectedPmNamespacedColor);
+            expect(outputXml).to.contain(expectedPmNamespace);
+            expect(outputXml).to.contain(expectedName);
+
+            done(err);
+        });
+    });
+
     it('Write Start Event Interstitial attributes', function(done) {
 
         // given


### PR DESCRIPTION
This fixes https://github.com/ProcessMaker/modeler/issues/1250.

It ensures that our custom `color` attribute is correctly namespaced to the `pm:` namespace. This will solve some validation issues around the BPMN, allowing requests to be created.

We added two task-related tests, but the behaviour is defined on the Base Element and as such will be a safe way to add the color attribute to any ProcessMaker BPMN output.

Related PR in modeler: https://github.com/ProcessMaker/modeler/pull/1252