### PR TITLE
Add pm:customIcon attribute

### DIFF
--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -98,6 +98,11 @@
           "type": "String"
         },
         {
+          "name": "customIcon",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
           "name": "validations",
           "isAttr": true,
           "type": "String"

--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -311,6 +311,11 @@
           "name": "assignedGroups",
           "isAttr": true,
           "type": "String"
+        },
+        {
+          "name": "customIcon",
+          "isAttr": true,
+          "type": "String"
         }
       ]
     },

--- a/test/fixtures/xml/processmaker-call-activity-custom-icon.part.bpmn
+++ b/test/fixtures/xml/processmaker-call-activity-custom-icon.part.bpmn
@@ -1,0 +1,6 @@
+<bpmn:callActivity
+    id="subprocess"
+    name="Subprocess"
+    pm:customIcon="PHN2Zz48L3N2Zz4="
+/>
+

--- a/test/fixtures/xml/processmaker-task-custom-icon.part.bpmn
+++ b/test/fixtures/xml/processmaker-task-custom-icon.part.bpmn
@@ -1,0 +1,6 @@
+<bpmn:task
+    id="task"
+    name="Task"
+    pm:customIcon="PHN2Zz48L3N2Zz4="
+/>
+

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -157,6 +157,24 @@ describe('read', function() {
             });
         });
 
+        it('Load Task With Custom Icon', function(done) {
+
+            // given
+            var xml = readFile('test/fixtures/xml/processmaker-task-custom-icon.part.bpmn');
+
+            // when
+            moddle.fromXML(xml, 'bpmn:Task', function(err, task) {
+                // then
+                expect(task).to.jsonEqual({
+                    '$type': 'bpmn:Task',
+                    'id': 'task',
+                    'name': 'Task',
+                    'customIcon': 'PHN2Zz48L3N2Zz4='
+                });
+                done(err);
+            });
+        });
+
         it('Load Interstitial Configuration', function(done) {
 
             // given

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -175,6 +175,24 @@ describe('read', function() {
             });
         });
 
+        it('Load Call Activity With Custom Icon', function(done) {
+
+            // given
+            var xml = readFile('test/fixtures/xml/processmaker-call-activity-custom-icon.part.bpmn');
+
+            // when
+            moddle.fromXML(xml, 'bpmn:CallActivity', function(err, task) {
+                // then
+                expect(task).to.jsonEqual({
+                    '$type': 'bpmn:CallActivity',
+                    'id': 'subprocess',
+                    'name': 'Subprocess',
+                    'customIcon': 'PHN2Zz48L3N2Zz4='
+                });
+                done(err);
+            });
+        });
+
         it('Load Interstitial Configuration', function(done) {
 
             // given

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -575,6 +575,30 @@ describe('write', function() {
         });
     });
 
+    it('Can write a Call Activity with custom icon as pm:customIcon', function(done) {
+
+        const base64EncodedMinimalSvg = 'PHN2Zz48L3N2Zz4=';
+        const withCustomIcon = {
+            name: 'Task',
+            customIcon: base64EncodedMinimalSvg
+        };
+
+        const callActivityWithCustomIcon = moddle.create('bpmn:CallActivity', withCustomIcon);
+
+        const expectedPmNamespace = 'xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd"';
+        const expectedName = `name="${withCustomIcon.name}"`;
+        const expectedPmNamespacedIcon = `pm:customIcon="${withCustomIcon.customIcon}"`;
+
+        write(callActivityWithCustomIcon, function(err, outputXml) {
+
+            expect(outputXml).to.contain(expectedPmNamespacedIcon);
+            expect(outputXml).to.contain(expectedPmNamespace);
+            expect(outputXml).to.contain(expectedName);
+
+            done(err);
+        });
+    });
+
     it('Write Start Event Interstitial attributes', function(done) {
 
         // given

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -551,6 +551,30 @@ describe('write', function() {
         });
     });
 
+    it('Can write task with custom icon as pm:customIcon', function(done) {
+
+        const base64EncodedMinimalSvg = 'PHN2Zz48L3N2Zz4=';
+        const withCustomIcon = {
+            name: 'Task',
+            customIcon: base64EncodedMinimalSvg
+        };
+
+        const taskWithCustomIcon = moddle.create('bpmn:Task', withCustomIcon);
+
+        const expectedPmNamespace = 'xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd"';
+        const expectedName = `name="${withCustomIcon.name}"`;
+        const expectedPmNamespacedIcon = `pm:customIcon="${withCustomIcon.customIcon}"`;
+
+        write(taskWithCustomIcon, function(err, outputXml) {
+
+            expect(outputXml).to.contain(expectedPmNamespacedIcon);
+            expect(outputXml).to.contain(expectedPmNamespace);
+            expect(outputXml).to.contain(expectedName);
+
+            done(err);
+        });
+    });
+
     it('Write Start Event Interstitial attributes', function(done) {
 
         // given


### PR DESCRIPTION
This new attribute is needed so that we can store a custom icon as per https://github.com/ProcessMaker/modeler/issues/1249.

Read and write tests have been added.
