### PR TITLE
FOUR-2891: Thrown signal to contain the data from the throwing process

### DIFF
--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -269,6 +269,19 @@
       ]
     },
     {
+      "name": "SignalEventDefinition",
+      "extends": [
+        "bpmn:SignalEventDefinition"
+      ],
+      "properties": [
+        {
+          "name": "config",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
       "name": "SequenceFlow",
       "extends": [
         "bpmn:SequenceFlow"

--- a/test/fixtures/xml/processmaker-signal-end-event.bpmn
+++ b/test/fixtures/xml/processmaker-signal-end-event.bpmn
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd"
+             targetNamespace="test">
+    <process id="EndEvent">
+        <startEvent id="start" />
+        <sequenceFlow sourceRef="start" targetRef="task2" />
+        <userTask id="task2" />
+        <sequenceFlow sourceRef="task2" targetRef="end" />
+        <endEvent id="end" pm:screenRef="screen-reference-id" pm:screenVersion="5" />
+        <endEvent id="node_5" name="Signal End Event">
+            <signalEventDefinition signalRef="MySignal" pm:config="{"payload":[{"id":"EXPRESSION","variable":"var","expression":"first_name ~ last_name"}]}"/>
+        </endEvent>
+        <signal id="MySignal" name="MySignal"/>
+    </process>
+</definitions>

--- a/test/fixtures/xml/processmaker-signal-event-definition.part.bpmn
+++ b/test/fixtures/xml/processmaker-signal-event-definition.part.bpmn
@@ -1,0 +1,1 @@
+<bpmn:signalEventDefinition pm:config="{}"/>

--- a/test/fixtures/xsd/ProcessMaker.xsd
+++ b/test/fixtures/xsd/ProcessMaker.xsd
@@ -116,6 +116,14 @@
         </xsd:complexContent>
     </xsd:complexType>
 
+    <xsd:complexType name="tPmSignalEventDefinition">
+        <xsd:complexContent>
+            <xsd:extension base="bpmn:tSignalEventDefinition">
+                <xsd:attribute name="config" type="xsd:string" use="optional"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
     <xsd:complexType name="tPmSequenceFlow">
         <xsd:complexContent>
             <xsd:extension base="bpmn:tSequenceFlow">

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -473,6 +473,21 @@ describe('read', function() {
             });
         });
 
+        it('Signal Event Definition', function(done) {
+            // given
+            var xml = readFile('test/fixtures/xml/processmaker-signal-event-definition.part.bpmn');
+
+            // when
+            moddle.fromXML(xml, 'bpmn:SignalEventDefinition', function(err, element) {
+                // then
+                expect(element).to.jsonEqual({
+                    '$type': 'bpmn:SignalEventDefinition',
+                    config: '{}',
+                });
+                done(err);
+            });
+        });
+
     });
 
 });

--- a/test/spec/xml/write.js
+++ b/test/spec/xml/write.js
@@ -498,6 +498,28 @@ describe('write', function() {
             });
         });
 
+        it('Write Signal Event Definition', function(done) {
+
+            // given
+            var fieldElem = moddle.create('bpmn:SignalEventDefinition', {
+                config: '{}',
+            });
+
+            var expectedXML =
+              '<bpmn:signalEventDefinition xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" ' +
+              'xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" ' +
+              'pm:config="{}" />';
+
+            // when
+            write(fieldElem, function(err, result) {
+
+                // then
+                expect(result).to.eql(expectedXML);
+
+                done(err);
+            });
+        });
+
     });
 
     it('Write Call Activity', function(done) {


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-2891](https://processmaker.atlassian.net/browse/FOUR-2891)

Now SignalEventiDefinition have a config parameter to store configuration like the signal payload to use