### PR TITLE
FOUR-15851: On Task Completed - Default Behavior (extend element destination)

### DIFF
--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -183,6 +183,11 @@
           "name": "screenVersion",
           "isAttr": true,
           "type": "String"
+        },
+        {
+          "name": "elementDestination",
+          "isAttr": true,
+          "type": "String"
         }
       ]
     },

--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -106,6 +106,11 @@
           "name": "validations",
           "isAttr": true,
           "type": "String"
+        },
+        {
+          "name": "elementDestination",
+          "isAttr": true,
+          "type": "String"
         }
       ]
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
Issue when a user opens two modelers in the same browser

## Solution
- Add extension for element destination
## How to Test
1. Open the modeler
2. Select a task
3. Configure element destination properties

## Related Tickets & Packages
- https://github.com/ProcessMaker/modeler/pull/1829
- https://processmaker.atlassian.net/browse/FOUR-15851
- https://processmaker.atlassian.net/browse/FOUR-15854

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
