### PR TITLE
FOUR-15508: [Summer24] Variable Task Due Date

### DIFF
--- a/resources/processmaker.json
+++ b/resources/processmaker.json
@@ -53,6 +53,16 @@
           "type": "Integer"
         },
         {
+          "name": "dueInVariable",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "isDueInVariable",
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
           "name": "notifyAfterRouting",
           "isAttr": true,
           "type": "Boolean"

--- a/test/fixtures/xml/processmaker-task-screen.part.bpmn
+++ b/test/fixtures/xml/processmaker-task-screen.part.bpmn
@@ -7,6 +7,8 @@
       pm:screenRef="420f95eb-76d8-459d-b56a-ea605bea4e3f"
       pm:screenVersion="10"
       pm:dueIn="10"
+      pm:dueInVariable="{{variable_mustache}}"
+      pm:isDueInVariable="true"
       pm:notifyAfterRouting="true"
       pm:notifyRequestCreator="false"
       startQuantity="1"

--- a/test/fixtures/xsd/ProcessMaker.xsd
+++ b/test/fixtures/xsd/ProcessMaker.xsd
@@ -16,6 +16,8 @@
                 <xsd:attribute name="interstitialScreenRef" type="xsd:string"/>
                 <xsd:attribute name="screenVersion" type="xsd:string" use="optional"/>
                 <xsd:attribute name="dueIn" type="xsd:decimal"/>
+                <xsd:attribute name="dueInVariable" type="xsd:string" use="optional"/>
+                <xsd:attribute name="isDueInVariable" type="xsd:boolean" default="false"/>
                 <xsd:attribute name="notifyAfterRouting" type="xsd:boolean" default="false"/>
                 <xsd:attribute name="notifyToRequestCreator" type="xsd:boolean" default="false"/>
                 <xsd:attribute name="assignment" type="xsd:string" default="requestor"/>

--- a/test/spec/xml/read.js
+++ b/test/spec/xml/read.js
@@ -130,6 +130,8 @@ describe('read', function() {
                     'screenRef': '420f95eb-76d8-459d-b56a-ea605bea4e3f',
                     'screenVersion': '10',
                     'dueIn': 10,
+                    'dueInVariable': '{{variable_mustache}}',
+                    'isDueInVariable': true,
                     'notifyAfterRouting': true,
                     'notifyRequestCreator': false,
                     'startQuantity': 1,


### PR DESCRIPTION
## Issue & Reproduction Steps
**Variable Task Due Date**
By implementing the feature to add dynamic variables to the due date configuration of tasks, users will gain greater control and customization options. This enhancement will empower users to create more flexible and adaptive task configurations that can automatically adjust due dates based on dynamic factors such as project progress, task dependencies, or external events.

PRD: https://processmaker.atlassian.net/wiki/spaces/PM4/pages/3423043585/Add+Due+Date+to+Cases
FIGMA: https://www.figma.com/file/RiBfT37iExrySseqYZuLg3/Summer-2024?type=design&node-id=103-14&mode=design&t=7oQ7Jtt0yX03U1x6-0

## Solution
As a user, I want to be able to add a dynamic variable on the due date’s task configuration

## How to Test
1. Access the Modeler.
2. Select a task (form or manual)
3. Go to the Configuration Rail.
4. Find the Due Date configuration field.
5. Be able to add a dynamic variable. If the dynamic variable does not exist, the default show be kept as 72 hours.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15508

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next